### PR TITLE
Add generic mapping for all EU countries and apply for PyPSA models

### DIFF
--- a/mappings/eu-countries.yaml
+++ b/mappings/eu-countries.yaml
@@ -1,0 +1,64 @@
+model:
+  - PyPSA-Eur-Sec 0.0.2
+  - PyPSA-Eur-Sec 0.5.0
+  - PyPSA-Eur-Sec 0.6.0
+native_regions:
+  - Austria
+  - Belgium
+  - Bulgaria
+  - Croatia
+  - Cyprus
+  - Czech Republic
+  - Denmark
+  - Estonia
+  - Finland
+  - France
+  - Germany
+  - Greece
+  - Hungary
+  - Ireland
+  - Italy
+  - Latvia
+  - Lithuania
+  - Luxembourg
+  - Malta
+  - The Netherlands
+  - Poland
+  - Portugal
+  - Romania
+  - Slovakia
+  - Slovenia
+  - Spain
+  - Sweden
+  - Switzerland
+  - United Kingdom
+  - Norway
+common_regions:
+  - EU27:
+    - Austria
+    - Belgium
+    - Bulgaria
+    - Croatia
+    - Cyprus
+    - Czech Republic
+    - Denmark
+    - Estonia
+    - Finland
+    - France
+    - Germany
+    - Greece
+    - Hungary
+    - Ireland
+    - Italy
+    - Latvia
+    - Lithuania
+    - Luxembourg
+    - Malta
+    - Poland
+    - Portugal
+    - Romania
+    - Slovakia
+    - Slovenia
+    - Spain
+    - Sweden
+    - The Netherlands


### PR DESCRIPTION
Adding a generic mapping from EU-countries to EU27, and apply it to the registered PyPSA models.

FYI @phackstock @nworbmot @martavp