### PR TITLE
Add region mappings for RECC 2.4

### DIFF
--- a/definitions/region/model_native_regions/recc_2.4.yaml
+++ b/definitions/region/model_native_regions/recc_2.4.yaml
@@ -1,0 +1,10 @@
+- RECC 2.4:
+  - RECC 2.4|UK
+  - RECC 2.4|France
+  - RECC 2.4|Germany
+  - RECC 2.4|Italy
+  - RECC 2.4|Poland
+  - RECC 2.4|Spain
+  - RECC 2.4|Other Eastern Europe
+  - RECC 2.4|Other Western Europe
+  - RECC 2.4|Other Central Europe

--- a/mappings/recc_2.4.yaml
+++ b/mappings/recc_2.4.yaml
@@ -1,0 +1,31 @@
+model: RECC 2.4
+native_regions:
+    - UK: RECC 2.4|UK
+    - France: RECC 2.4|France
+    - Germany: RECC 2.4|Germany
+    - Italy: RECC 2.4|Italy
+    - Poland: RECC 2.4|Poland
+    - Spain: RECC 2.4|Spain
+    - R32EU12-M: RECC 2.4|Other Eastern Europe
+    - Oth_R32EU15: RECC 2.4|Other Western Europe
+    - Oth_R32EU12-H: RECC 2.4|Other Central Europe
+common_regions:
+  - EU27:
+    - France
+    - Germany
+    - Italy
+    - Poland
+    - Spain
+    - R32EU12-M
+    - Oth_R32EU15
+    - Oth_R32EU12-H
+  - Europe:
+    - UK
+    - France
+    - Germany
+    - Italy
+    - Poland
+    - Spain
+    - R32EU12-M
+    - Oth_R32EU15
+    - Oth_R32EU12-H


### PR DESCRIPTION
This PR adds the regions and region-mappings for the RECC 2.4 model.

@stefanpauliuk, I tried to give more intuitive, human-readable names to the three aggregate regions - could you please review and let me know if that makes (sort-of) sense?