### PR TITLE
Add region mapping for alternative-ISO2 codes

### DIFF
--- a/mappings/eu-countries-iso2-ec.yaml
+++ b/mappings/eu-countries-iso2-ec.yaml
@@ -1,5 +1,5 @@
 # this mapping file is intended for models that use have a country-resolution of Europe
-# and use ISO2 codes for country names
+# and use the alternative ISO2 codes for country names used by the European Commission
 model:
  - FORECAST v1.0
 native_regions:
@@ -15,7 +15,7 @@ native_regions:
  - FI: Finland
  - FR: France
  - DE: Germany
- - GR: Greece
+ - EL: Greece  # alternative ISO2 code used by the European Commission
  - HU: Hungary
  - IE: Ireland
  - IS: Iceland
@@ -33,7 +33,7 @@ native_regions:
  - SI: Slovenia
  - ES: Spain
  - SE: Sweden
- - UK: United Kingdom
+ - UK: United Kingdom  # alternative ISO2 code used by the European Commission
 common_regions:
   - EU27:
     - AT
@@ -47,7 +47,7 @@ common_regions:
     - FI
     - FR
     - DE
-    - GR
+    - EL  # alternative ISO2 code used by the European Commission
     - HU
     - IE
     - IT
@@ -75,7 +75,7 @@ common_regions:
     - FI
     - FR
     - DE
-    - GR
+    - EL  # alternative ISO2 code used by the European Commission
     - HU
     - IE
     - IT
@@ -91,7 +91,7 @@ common_regions:
     - SI
     - ES
     - SE
-    - UK
+    - UK  # alternative ISO2 code used by the European Commission
   - Europe:
     - AT
     - BE
@@ -104,7 +104,7 @@ common_regions:
     - FI
     - FR
     - DE
-    - GR
+    - EL  # alternative ISO2 code used by the European Commission
     - HU
     - IE
     - IT
@@ -120,7 +120,7 @@ common_regions:
     - SI
     - ES
     - SE
-    - UK
+    - UK  # alternative ISO2 code used by the European Commission
     - CH
     - IS
     - "NO"

--- a/mappings/eu-countries-iso2-ec.yaml
+++ b/mappings/eu-countries-iso2-ec.yaml
@@ -1,8 +1,7 @@
 # this mapping file is intended for models that use have a country-resolution of Europe
 # and use ISO2 codes for country names
 model:
- - E4SMA-EU-TIMES 1.0
- - NEMESIS 5.1
+ - FORECAST v1.0
 native_regions:
  - AT: Austria
  - BE: Belgium

--- a/mappings/eu-countries-iso2.yaml
+++ b/mappings/eu-countries-iso2.yaml
@@ -34,7 +34,7 @@ native_regions:
  - SI: Slovenia
  - ES: Spain
  - SE: Sweden
- - UK: United Kingdom
+ - GB: United Kingdom
 common_regions:
   - EU27:
     - AT
@@ -92,7 +92,7 @@ common_regions:
     - SI
     - ES
     - SE
-    - UK
+    - GB
   - Europe:
     - AT
     - BE
@@ -121,7 +121,7 @@ common_regions:
     - SI
     - ES
     - SE
-    - UK
+    - GB
     - CH
     - IS
     - "NO"


### PR DESCRIPTION
Per a comment by @bapboitier, this PR cleans up inconsistent mapping of alternative ISO2 codes used by the European Commission.

fyi @phackstock 