### PR TITLE
Add ISO3-codes to the native regions of the AIM model

### DIFF
--- a/definitions/region/model_native_regions/aim_2.1.yaml
+++ b/definitions/region/model_native_regions/aim_2.1.yaml
@@ -26,7 +26,7 @@
   - AIM/CGE 2.1|Rest of Europe:
       countries: ALB, AND, BGR, BIH, CHE, FRO, GIB, HRV, ISL, LIE, MCO, MKD, MNE,
         NOR, ROU, SJM, SMR, SRB, VAT
-  - AIM/CGE 2.1|Rest of Brazil:
+  - AIM/CGE 2.1|Rest of Latin America:
       countries: ABW, AIA, ANT, ARG, ATG, BHS, BLZ, BMU, BOL, BRB, BVT, CHL, COL,
         CRI, CUB, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GRL, GTM, GUF, GUY, HND, HTI,
         JAM, KNA, LCA, MEX, MSR, MTQ, NIC, PAN, PER, PRI, PRY, SGS, SLV, SPM, SUR,

--- a/definitions/region/model_native_regions/aim_2.1.yaml
+++ b/definitions/region/model_native_regions/aim_2.1.yaml
@@ -1,18 +1,46 @@
 - AIM/CGE 2.1:
-  - AIM/CGE 2.1|Brazil
-  - AIM/CGE 2.1|Canada
-  - AIM/CGE 2.1|China
-  - AIM/CGE 2.1|Former USSR
-  - AIM/CGE 2.1|India
-  - AIM/CGE 2.1|Japan
-  - AIM/CGE 2.1|Turkey
-  - AIM/CGE 2.1|USA
-  - AIM/CGE 2.1|Other Africa
-  - AIM/CGE 2.1|EU
-  - AIM/CGE 2.1|Rest of Europe
-  - AIM/CGE 2.1|Rest of Brazil
-  - AIM/CGE 2.1|Middle East
-  - AIM/CGE 2.1|North Africa
-  - AIM/CGE 2.1|New Zealand and Australia
-  - AIM/CGE 2.1|Rest of Asia
-  - AIM/CGE 2.1|Rest of East and South East Asia
+  - AIM/CGE 2.1|Brazil:
+      countries: BRA
+  - AIM/CGE 2.1|Canada:
+      countries: CAN
+  - AIM/CGE 2.1|China:
+      countries: CHN, HKG
+  - AIM/CGE 2.1|Former USSR:
+      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TJK, TKM, UKR, UZB
+  - AIM/CGE 2.1|India:
+      countries: IND
+  - AIM/CGE 2.1|Japan:
+      countries: JPN
+  - AIM/CGE 2.1|Turkey:
+      countries: TUR
+  - AIM/CGE 2.1|USA:
+      countries: USA
+  - AIM/CGE 2.1|Other Africa:
+      countries: AGO, BDI, BEN, BFA, BWA, CAF, CIV, CMR, COD, COG, COM, CPV, DJI,
+        ERI, ESH, ETH, GAB, GHA, GIN, GMB, GNB, GNQ, KEN, LBR, LSO, MDG, MLI, MOZ,
+        MRT, MUS, MWI, MYT, NAM, NER, NGA, REU, RWA, SDN, SEN, SHN, SLE, SOM, STP,
+        SWZ, SYC, TCD, TGO, TZA, UGA, ZAF, ZMB, ZWE
+  - AIM/CGE 2.1|EU:
+      countries: AUT, BEL, CYP, CZE, DEU, DNK, ESP, EST, FIN, FRA, GBR, GRC, HUN,
+        IRL, ITA, LTU, LUX, LVA, MLT, NLD, POL, PRT, SVK, SVN, SWE
+  - AIM/CGE 2.1|Rest of Europe:
+      countries: ALB, AND, BGR, BIH, CHE, FRO, GIB, HRV, ISL, LIE, MCO, MKD, MNE,
+        NOR, ROU, SJM, SMR, SRB, VAT
+  - AIM/CGE 2.1|Rest of Brazil:
+      countries: ABW, AIA, ANT, ARG, ATG, BHS, BLZ, BMU, BOL, BRB, BVT, CHL, COL,
+        CRI, CUB, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GRL, GTM, GUF, GUY, HND, HTI,
+        JAM, KNA, LCA, MEX, MSR, MTQ, NIC, PAN, PER, PRI, PRY, SGS, SLV, SPM, SUR,
+        TCA, TTO, URY, VCT, VEN, VGB, VIR
+  - AIM/CGE 2.1|Middle East:
+      countries: ARE, BHR, IRN, IRQ, ISR, JOR, KWT, LBN, OMN, QAT, SAU, SYR, YEM
+  - AIM/CGE 2.1|North Africa:
+      countries: DZA, EGY, LBY, MAR, TUN
+  - AIM/CGE 2.1|New Zealand and Australia:
+      countries: AUS, NZL
+  - AIM/CGE 2.1|Rest of Asia:
+      countries: AFG, ASM, ATF, BGD, BRN, BTN, CCK, COK, CXR, FJI, FSM, GUM, HMD,
+        IOT, KIR, LKA, MDV, MHL, MNP, NCL, NFK, NIU, NPL, NRU, PAK, PCN, PLW, PNG,
+        PYF, SLB, TKL, TON, TUV, UMI, VUT, WLF, WSM
+  - AIM/CGE 2.1|Rest of East and South East Asia:
+      countries: IDN, KHM, KOR, LAO, MMR, MNG, MYS, PHL, PRK, SGP, THA, TLS, TWN,
+        VNM

--- a/definitions/region/model_native_regions/aim_2.2.yaml
+++ b/definitions/region/model_native_regions/aim_2.2.yaml
@@ -1,18 +1,46 @@
 - AIM/CGE 2.2:
-  - AIM/CGE 2.2|Brazil
-  - AIM/CGE 2.2|Canada
-  - AIM/CGE 2.2|China
-  - AIM/CGE 2.2|Former USSR
-  - AIM/CGE 2.2|India
-  - AIM/CGE 2.2|Japan
-  - AIM/CGE 2.2|Turkey
-  - AIM/CGE 2.2|USA
-  - AIM/CGE 2.2|Other Africa
-  - AIM/CGE 2.2|EU
-  - AIM/CGE 2.2|Rest of Europe
-  - AIM/CGE 2.2|Rest of Brazil
-  - AIM/CGE 2.2|Middle East
-  - AIM/CGE 2.2|North Africa
-  - AIM/CGE 2.2|New Zealand and Australia
-  - AIM/CGE 2.2|Rest of Asia
-  - AIM/CGE 2.2|Rest of East and South East Asia
+  - AIM/CGE 2.2|Brazil:
+      countries: BRA
+  - AIM/CGE 2.2|Canada:
+      countries: CAN
+  - AIM/CGE 2.2|China:
+      countries: CHN, HKG
+  - AIM/CGE 2.2|Former USSR:
+      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TJK, TKM, UKR, UZB
+  - AIM/CGE 2.2|India:
+      countries: IND
+  - AIM/CGE 2.2|Japan:
+      countries: JPN
+  - AIM/CGE 2.2|Turkey:
+      countries: TUR
+  - AIM/CGE 2.2|USA:
+      countries: USA
+  - AIM/CGE 2.2|Other Africa:
+      countries: AGO, BDI, BEN, BFA, BWA, CAF, CIV, CMR, COD, COG, COM, CPV, DJI,
+        ERI, ESH, ETH, GAB, GHA, GIN, GMB, GNB, GNQ, KEN, LBR, LSO, MDG, MLI, MOZ,
+        MRT, MUS, MWI, MYT, NAM, NER, NGA, REU, RWA, SDN, SEN, SHN, SLE, SOM, STP,
+        SWZ, SYC, TCD, TGO, TZA, UGA, ZAF, ZMB, ZWE
+  - AIM/CGE 2.2|EU:
+      countries: AUT, BEL, CYP, CZE, DEU, DNK, ESP, EST, FIN, FRA, GBR, GRC, HUN,
+        IRL, ITA, LTU, LUX, LVA, MLT, NLD, POL, PRT, SVK, SVN, SWE
+  - AIM/CGE 2.2|Rest of Europe:
+      countries: ALB, AND, BGR, BIH, CHE, FRO, GIB, HRV, ISL, LIE, MCO, MKD, MNE,
+        NOR, ROU, SJM, SMR, SRB, VAT
+  - AIM/CGE 2.2|Rest of Brazil:
+      countries: ABW, AIA, ANT, ARG, ATG, BHS, BLZ, BMU, BOL, BRB, BVT, CHL, COL,
+        CRI, CUB, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GRL, GTM, GUF, GUY, HND, HTI,
+        JAM, KNA, LCA, MEX, MSR, MTQ, NIC, PAN, PER, PRI, PRY, SGS, SLV, SPM, SUR,
+        TCA, TTO, URY, VCT, VEN, VGB, VIR
+  - AIM/CGE 2.2|Middle East:
+      countries: ARE, BHR, IRN, IRQ, ISR, JOR, KWT, LBN, OMN, QAT, SAU, SYR, YEM
+  - AIM/CGE 2.2|North Africa:
+      countries: DZA, EGY, LBY, MAR, TUN
+  - AIM/CGE 2.2|New Zealand and Australia:
+      countries: AUS, NZL
+  - AIM/CGE 2.2|Rest of Asia:
+      countries: AFG, ASM, ATF, BGD, BRN, BTN, CCK, COK, CXR, FJI, FSM, GUM, HMD,
+        IOT, KIR, LKA, MDV, MHL, MNP, NCL, NFK, NIU, NPL, NRU, PAK, PCN, PLW, PNG,
+        PYF, SLB, TKL, TON, TUV, UMI, VUT, WLF, WSM
+  - AIM/CGE 2.2|Rest of East and South East Asia:
+      countries: IDN, KHM, KOR, LAO, MMR, MNG, MYS, PHL, PRK, SGP, THA, TLS, TWN,
+        VNM

--- a/definitions/region/model_native_regions/aim_2.2.yaml
+++ b/definitions/region/model_native_regions/aim_2.2.yaml
@@ -26,7 +26,7 @@
   - AIM/CGE 2.2|Rest of Europe:
       countries: ALB, AND, BGR, BIH, CHE, FRO, GIB, HRV, ISL, LIE, MCO, MKD, MNE,
         NOR, ROU, SJM, SMR, SRB, VAT
-  - AIM/CGE 2.2|Rest of Brazil:
+  - AIM/CGE 2.2|Rest of Latin America:
       countries: ABW, AIA, ANT, ARG, ATG, BHS, BLZ, BMU, BOL, BRB, BVT, CHL, COL,
         CRI, CUB, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GRL, GTM, GUF, GUY, HND, HTI,
         JAM, KNA, LCA, MEX, MSR, MTQ, NIC, PAN, PER, PRI, PRY, SGS, SLV, SPM, SUR,


### PR DESCRIPTION
For use in automated processing and validation, this PR adds the ISO3-codes to the native regions of the AIM model