### PR TITLE
Add ISO3-codes to the native regions of the REMIND model

### DIFF
--- a/definitions/region/model_native_regions/REMIND_2.0.yml
+++ b/definitions/region/model_native_regions/REMIND_2.0.yml
@@ -10,30 +10,30 @@
   - REMIND 2.0|Other Asia:
       countries: AFG, ASM, ATF, BGD, BRN, BTN, CCK, COK, CXR, FJI, FSM, GUM, IDN,
         IOT, KHM, KIR, KOR, LAO, LKA, MDV, MHL, MMR, MNG, MNP, MYS, NCL, NFK, NIU,
-        NPL, NRU, PAK, PCN, PHL, PLW, PNG, PRK, PYF, SGP, SLB, TJK, TKL, TLS, TON,
+        NPL, NRU, PAK, PCN, PHL, PLW, PNG, PRK, PYF, SGP, SLB, TKL, TLS, TON, THA
         TUV, UMI, VNM, VUT, WLF, WSM
   - REMIND 2.0|Latin America and the Caribbean:
       countries: ABW, AIA, ANT, ARG, ATA, ATG, BHS, BLM, BLZ, BMU, BOL, BRA, BRB,
         BVT, CHL, COL, CRI, CUB, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GTM, GUF, GUY,
         HND, HTI, JAM, KNA, LCA, MAF, MEX, MSR, MTQ, NIC, PAN, PER, PRI, PRY, SGS,
-        SLV, SUR, TCD, TTO, URY, VCT, VEN, VGB, VIR
+        SLV, SUR, TTO, URY, VCT, VEN, VGB, VIR, BES, CUW, SXM, TCA
   - REMIND 2.0|Middle East and North Africa:
       countries: ARE, BHR, DZA, EGY, ESH, IRN, IRQ, ISR, JOR, KWT, LBN, LBY, MAR,
-        OMN, PSE, QAT, SAU, SDN, TCA, TUN, YEM
+        OMN, PSE, QAT, SAU, SDN, TUN, YEM, SYR
   - REMIND 2.0|Russia and Reforming Economies:
-      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TKM, UKR, UZB
+      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TKM, UKR, UZB, TJK
   - REMIND 2.0|Sub-Saharan Africa:
       countries: AGO, BDI, BEN, BFA, BWA, CAF, CIV, CMR, COD, COG, COM, CPV, DJI,
         ERI, ETH, GAB, GHA, GIN, GMB, GNB, GNQ, KEN, LBR, LSO, MDG, MLI, MOZ, MRT,
         MUS, MWI, MYT, NAM, NER, NGA, REU, RWA, SEN, SHN, SLE, SOM, SSD, STP, SWZ,
-        SYC, SYR, TGO, THA, TZA, UGA, ZAF, ZMB, ZWE
+        SYC, TGO, TZA, UGA, ZAF, ZMB, ZWE, TCD
   - REMIND 2.0|United States of America:
       countries: USA
 # 12-region version of REMIND
   - REMIND 2.0|EU 28:
       countries: ALA, AUT, BEL, BGR, CYP, CZE, DNK, ESP, EST, FIN, FRO, GGY, GIB,
         GRC, HRV, HUN, IMN, IRL, ITA, JEY, LTU, LUX, LVA, MLT, NLD, POL, PRT, ROU,
-        SVK, SVN, SWE
+        SVK, SVN, SWE, FRA, DEU, ITA, GIB, GGY, GBR
   - REMIND 2.0|Non-EU28 Europe:
       countries: ALB, AND, BIH, CHE, GRL, ISL, LIE, MCO, MKD, MNE, NOR, SJM, SMR,
         SRB, TUR, VAT
@@ -43,23 +43,23 @@
   - REMIND 2.0|France:
       countries: FRA
   - REMIND 2.0|United Kingdom and Ireland:
-      countries: GBR
+      countries: GIB, GGY, IRL, IMN, JEY, GBR
   - REMIND 2.0|EU Center-East Europe:
-      countries: ''
+      countries: CZE, EST, LVA, LTU, POL, SVK
   - REMIND 2.0|EU Center-South Europe:
-      countries: ''
+      countries: BGR, HRV, HUN, ROU, SVN
   - REMIND 2.0|EU North-Center Europe:
-      countries: ''
+      countries: ALA, DNK, FRO, FIN, SWE
   - REMIND 2.0|EU South-Center Europe:
-      countries: ''
+      countries: CYP, GRC, ITA, MLT
   - REMIND 2.0|EU South-West Europe:
-      countries: ''
+      countries: PRT, ESP
   - REMIND 2.0|EU North-West Europe:
-      countries: ''
+      countries: AUT, BEL, LUX, NLD
   - REMIND 2.0|Non-EU Northern Europe:
-      countries: ''
+      countries: ISL, LIE, NOR, SJM, CHE, GRL
   - REMIND 2.0|Non-EU Southern Europe:
-      countries: ''
+      countries: ALB, AND, BIH, VAT, MKD, MCO, MNE, SMR, SRB, TUR
 # exogenously aggregated regions
   - REMIND 2.0|EU 27:
-      countries: ''
+      countries: ALA, AUT, BEL, BGR, HRV, CYP, CZE, DNK, EST, FRO, FIN, FRA, DEU, GRC, HUN, ITA, LVA, LTU, LUX, MLT, NLD, POL, PRT, ROU, SVK, SVN, ESP, SWE

--- a/definitions/region/model_native_regions/REMIND_2.0.yml
+++ b/definitions/region/model_native_regions/REMIND_2.0.yml
@@ -1,28 +1,65 @@
 - REMIND 2.0:
-  - REMIND 2.0|Canada, Australia, New Zealand
-  - REMIND 2.0|China and Taiwan
-  - REMIND 2.0|India
-  - REMIND 2.0|Japan
-  - REMIND 2.0|Other Asia
-  - REMIND 2.0|Latin America and the Caribbean
-  - REMIND 2.0|Middle East and North Africa
-  - REMIND 2.0|Russia and Reforming Economies
-  - REMIND 2.0|Sub-Saharan Africa
-  - REMIND 2.0|United States of America
+  - REMIND 2.0|Canada, Australia, New Zealand:
+      countries: AUS, CAN, HMD, NZL, SPM
+  - REMIND 2.0|China and Taiwan:
+      countries: CHN, HKG, MAC, TWN
+  - REMIND 2.0|India:
+      countries: IND
+  - REMIND 2.0|Japan:
+      countries: JPN
+  - REMIND 2.0|Other Asia:
+      countries: AFG, ASM, ATF, BGD, BRN, BTN, CCK, COK, CXR, FJI, FSM, GUM, IDN,
+        IOT, KHM, KIR, KOR, LAO, LKA, MDV, MHL, MMR, MNG, MNP, MYS, NCL, NFK, NIU,
+        NPL, NRU, PAK, PCN, PHL, PLW, PNG, PRK, PYF, SGP, SLB, TJK, TKL, TLS, TON,
+        TUV, UMI, VNM, VUT, WLF, WSM
+  - REMIND 2.0|Latin America and the Caribbean:
+      countries: ABW, AIA, ANT, ARG, ATA, ATG, BHS, BLM, BLZ, BMU, BOL, BRA, BRB,
+        BVT, CHL, COL, CRI, CUB, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GTM, GUF, GUY,
+        HND, HTI, JAM, KNA, LCA, MAF, MEX, MSR, MTQ, NIC, PAN, PER, PRI, PRY, SGS,
+        SLV, SUR, TCD, TTO, URY, VCT, VEN, VGB, VIR
+  - REMIND 2.0|Middle East and North Africa:
+      countries: ARE, BHR, DZA, EGY, ESH, IRN, IRQ, ISR, JOR, KWT, LBN, LBY, MAR,
+        OMN, PSE, QAT, SAU, SDN, TCA, TUN, YEM
+  - REMIND 2.0|Russia and Reforming Economies:
+      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TKM, UKR, UZB
+  - REMIND 2.0|Sub-Saharan Africa:
+      countries: AGO, BDI, BEN, BFA, BWA, CAF, CIV, CMR, COD, COG, COM, CPV, DJI,
+        ERI, ETH, GAB, GHA, GIN, GMB, GNB, GNQ, KEN, LBR, LSO, MDG, MLI, MOZ, MRT,
+        MUS, MWI, MYT, NAM, NER, NGA, REU, RWA, SEN, SHN, SLE, SOM, SSD, STP, SWZ,
+        SYC, SYR, TGO, THA, TZA, UGA, ZAF, ZMB, ZWE
+  - REMIND 2.0|United States of America:
+      countries: USA
 # 12-region version of REMIND
-  - REMIND 2.0|EU 28
-  - REMIND 2.0|Non-EU28 Europe
+  - REMIND 2.0|EU 28:
+      countries: ALA, AUT, BEL, BGR, CYP, CZE, DNK, ESP, EST, FIN, FRO, GGY, GIB,
+        GRC, HRV, HUN, IMN, IRL, ITA, JEY, LTU, LUX, LVA, MLT, NLD, POL, PRT, ROU,
+        SVK, SVN, SWE
+  - REMIND 2.0|Non-EU28 Europe:
+      countries: ALB, AND, BIH, CHE, GRL, ISL, LIE, MCO, MKD, MNE, NOR, SJM, SMR,
+        SRB, TUR, VAT
 # 21-region version of REMIND
-  - REMIND 2.0|Germany
-  - REMIND 2.0|France
-  - REMIND 2.0|United Kingdom and Ireland
-  - REMIND 2.0|EU Center-East Europe
-  - REMIND 2.0|EU Center-South Europe
-  - REMIND 2.0|EU North-Center Europe
-  - REMIND 2.0|EU South-Center Europe
-  - REMIND 2.0|EU South-West Europe
-  - REMIND 2.0|EU North-West Europe
-  - REMIND 2.0|Non-EU Northern Europe
-  - REMIND 2.0|Non-EU Southern Europe
+  - REMIND 2.0|Germany:
+      countries: DEU
+  - REMIND 2.0|France:
+      countries: FRA
+  - REMIND 2.0|United Kingdom and Ireland:
+      countries: GBR
+  - REMIND 2.0|EU Center-East Europe:
+      countries: ''
+  - REMIND 2.0|EU Center-South Europe:
+      countries: ''
+  - REMIND 2.0|EU North-Center Europe:
+      countries: ''
+  - REMIND 2.0|EU South-Center Europe:
+      countries: ''
+  - REMIND 2.0|EU South-West Europe:
+      countries: ''
+  - REMIND 2.0|EU North-West Europe:
+      countries: ''
+  - REMIND 2.0|Non-EU Northern Europe:
+      countries: ''
+  - REMIND 2.0|Non-EU Southern Europe:
+      countries: ''
 # exogenously aggregated regions
-  - REMIND 2.0|EU 27
+  - REMIND 2.0|EU 27:
+      countries: ''

--- a/definitions/region/model_native_regions/REMIND_2.0.yml
+++ b/definitions/region/model_native_regions/REMIND_2.0.yml
@@ -62,4 +62,5 @@
       countries: ALB, AND, BIH, VAT, MKD, MCO, MNE, SMR, SRB, TUR
 # exogenously aggregated regions
   - REMIND 2.0|EU 27:
-      countries: ALA, AUT, BEL, BGR, HRV, CYP, CZE, DNK, EST, FRO, FIN, FRA, DEU, GRC, HUN, ITA, LVA, LTU, LUX, MLT, NLD, POL, PRT, ROU, SVK, SVN, ESP, SWE
+      countries: ALA, AUT, BEL, BGR, HRV, CYP, CZE, DNK, EST, FRO, FIN, FRA, DEU, GRC,
+        HUN, ITA, LVA, LTU, LUX, MLT, NLD, POL, PRT, ROU, SVK, SVN, ESP, SWE

--- a/definitions/region/model_native_regions/REMIND_2.1.yml
+++ b/definitions/region/model_native_regions/REMIND_2.1.yml
@@ -10,30 +10,30 @@
   - REMIND 2.1|Other Asia:
       countries: AFG, ASM, ATF, BGD, BRN, BTN, CCK, COK, CXR, FJI, FSM, GUM, IDN,
         IOT, KHM, KIR, KOR, LAO, LKA, MDV, MHL, MMR, MNG, MNP, MYS, NCL, NFK, NIU,
-        NPL, NRU, PAK, PCN, PHL, PLW, PNG, PRK, PYF, SGP, SLB, TJK, TKL, TLS, TON,
+        NPL, NRU, PAK, PCN, PHL, PLW, PNG, PRK, PYF, SGP, SLB, TKL, TLS, TON, THA
         TUV, UMI, VNM, VUT, WLF, WSM
   - REMIND 2.1|Latin America and the Caribbean:
       countries: ABW, AIA, ANT, ARG, ATA, ATG, BHS, BLM, BLZ, BMU, BOL, BRA, BRB,
         BVT, CHL, COL, CRI, CUB, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GTM, GUF, GUY,
         HND, HTI, JAM, KNA, LCA, MAF, MEX, MSR, MTQ, NIC, PAN, PER, PRI, PRY, SGS,
-        SLV, SUR, TCD, TTO, URY, VCT, VEN, VGB, VIR
+        SLV, SUR, TTO, URY, VCT, VEN, VGB, VIR, BES, CUW, SXM, TCA
   - REMIND 2.1|Middle East and North Africa:
       countries: ARE, BHR, DZA, EGY, ESH, IRN, IRQ, ISR, JOR, KWT, LBN, LBY, MAR,
-        OMN, PSE, QAT, SAU, SDN, TCA, TUN, YEM
+        OMN, PSE, QAT, SAU, SDN, TUN, YEM, SYR
   - REMIND 2.1|Russia and Reforming Economies:
-      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TKM, UKR, UZB
+      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TKM, UKR, UZB, TJK
   - REMIND 2.1|Sub-Saharan Africa:
       countries: AGO, BDI, BEN, BFA, BWA, CAF, CIV, CMR, COD, COG, COM, CPV, DJI,
         ERI, ETH, GAB, GHA, GIN, GMB, GNB, GNQ, KEN, LBR, LSO, MDG, MLI, MOZ, MRT,
         MUS, MWI, MYT, NAM, NER, NGA, REU, RWA, SEN, SHN, SLE, SOM, SSD, STP, SWZ,
-        SYC, SYR, TGO, THA, TZA, UGA, ZAF, ZMB, ZWE
+        SYC, TGO, TZA, UGA, ZAF, ZMB, ZWE, TCD
   - REMIND 2.1|United States of America:
       countries: USA
 # 12-region version of REMIND
   - REMIND 2.1|EU 28:
-      countries: ALA, AUT, BEL, BGR, CYP, CZE, DEU, DNK, ESP, EST, FIN, FRA, FRO,
-        GGY, GIB, GRC, HRV, HUN, IMN, IRL, ITA, JEY, LTU, LUX, LVA, MLT, NLD, POL,
-        PRT, ROU, SVK, SVN, SWE
+      countries: ALA, AUT, BEL, BGR, CYP, CZE, DNK, ESP, EST, FIN, FRO, GGY, GIB,
+        GRC, HRV, HUN, IMN, IRL, ITA, JEY, LTU, LUX, LVA, MLT, NLD, POL, PRT, ROU,
+        SVK, SVN, SWE, FRA, DEU, ITA, GIB, GGY, GBR
   - REMIND 2.1|Non-EU28 Europe:
       countries: ALB, AND, BIH, CHE, GRL, ISL, LIE, MCO, MKD, MNE, NOR, SJM, SMR,
         SRB, TUR, VAT
@@ -43,23 +43,24 @@
   - REMIND 2.1|France:
       countries: FRA
   - REMIND 2.1|United Kingdom and Ireland:
-      countries: GBR
+      countries: GIB, GGY, IRL, IMN, JEY, GBR
   - REMIND 2.1|EU Center-East Europe:
-      countries: ''
+      countries: CZE, EST, LVA, LTU, POL, SVK
   - REMIND 2.1|EU Center-South Europe:
-      countries: ''
+      countries: BGR, HRV, HUN, ROU, SVN
   - REMIND 2.1|EU North-Center Europe:
-      countries: ''
+      countries: ALA, DNK, FRO, FIN, SWE
   - REMIND 2.1|EU South-Center Europe:
-      countries: ''
+      countries: CYP, GRC, ITA, MLT
   - REMIND 2.1|EU South-West Europe:
-      countries: ''
+      countries: PRT, ESP
   - REMIND 2.1|EU North-West Europe:
-      countries: ''
+      countries: AUT, BEL, LUX, NLD
   - REMIND 2.1|Non-EU Northern Europe:
-      countries: ''
+      countries: ISL, LIE, NOR, SJM, CHE, GRL
   - REMIND 2.1|Non-EU Southern Europe:
-      countries: ''
+      countries: ALB, AND, BIH, VAT, MKD, MCO, MNE, SMR, SRB, TUR
 # exogenously aggregated regions
   - REMIND 2.1|EU 27:
-      countries: ''
+      countries: ALA, AUT, BEL, BGR, HRV, CYP, CZE, DNK, EST, FRO, FIN, FRA, DEU, GRC,
+        HUN, ITA, LVA, LTU, LUX, MLT, NLD, POL, PRT, ROU, SVK, SVN, ESP, SWE

--- a/definitions/region/model_native_regions/REMIND_2.1.yml
+++ b/definitions/region/model_native_regions/REMIND_2.1.yml
@@ -1,28 +1,65 @@
 - REMIND 2.1:
-  - REMIND 2.1|Canada, Australia, New Zealand
-  - REMIND 2.1|China and Taiwan
-  - REMIND 2.1|India
-  - REMIND 2.1|Japan
-  - REMIND 2.1|Other Asia
-  - REMIND 2.1|Latin America and the Caribbean
-  - REMIND 2.1|Middle East and North Africa
-  - REMIND 2.1|Russia and Reforming Economies
-  - REMIND 2.1|Sub-Saharan Africa
-  - REMIND 2.1|United States of America
+  - REMIND 2.1|Canada, Australia, New Zealand:
+      countries: AUS, CAN, HMD, NZL, SPM
+  - REMIND 2.1|China and Taiwan:
+      countries: CHN, HKG, MAC, TWN
+  - REMIND 2.1|India:
+      countries: IND
+  - REMIND 2.1|Japan:
+      countries: JPN
+  - REMIND 2.1|Other Asia:
+      countries: AFG, ASM, ATF, BGD, BRN, BTN, CCK, COK, CXR, FJI, FSM, GUM, IDN,
+        IOT, KHM, KIR, KOR, LAO, LKA, MDV, MHL, MMR, MNG, MNP, MYS, NCL, NFK, NIU,
+        NPL, NRU, PAK, PCN, PHL, PLW, PNG, PRK, PYF, SGP, SLB, TJK, TKL, TLS, TON,
+        TUV, UMI, VNM, VUT, WLF, WSM
+  - REMIND 2.1|Latin America and the Caribbean:
+      countries: ABW, AIA, ANT, ARG, ATA, ATG, BHS, BLM, BLZ, BMU, BOL, BRA, BRB,
+        BVT, CHL, COL, CRI, CUB, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GTM, GUF, GUY,
+        HND, HTI, JAM, KNA, LCA, MAF, MEX, MSR, MTQ, NIC, PAN, PER, PRI, PRY, SGS,
+        SLV, SUR, TCD, TTO, URY, VCT, VEN, VGB, VIR
+  - REMIND 2.1|Middle East and North Africa:
+      countries: ARE, BHR, DZA, EGY, ESH, IRN, IRQ, ISR, JOR, KWT, LBN, LBY, MAR,
+        OMN, PSE, QAT, SAU, SDN, TCA, TUN, YEM
+  - REMIND 2.1|Russia and Reforming Economies:
+      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TKM, UKR, UZB
+  - REMIND 2.1|Sub-Saharan Africa:
+      countries: AGO, BDI, BEN, BFA, BWA, CAF, CIV, CMR, COD, COG, COM, CPV, DJI,
+        ERI, ETH, GAB, GHA, GIN, GMB, GNB, GNQ, KEN, LBR, LSO, MDG, MLI, MOZ, MRT,
+        MUS, MWI, MYT, NAM, NER, NGA, REU, RWA, SEN, SHN, SLE, SOM, SSD, STP, SWZ,
+        SYC, SYR, TGO, THA, TZA, UGA, ZAF, ZMB, ZWE
+  - REMIND 2.1|United States of America:
+      countries: USA
 # 12-region version of REMIND
-  - REMIND 2.1|EU 28
-  - REMIND 2.1|Non-EU28 Europe
+  - REMIND 2.1|EU 28:
+      countries: ALA, AUT, BEL, BGR, CYP, CZE, DEU, DNK, ESP, EST, FIN, FRA, FRO,
+        GGY, GIB, GRC, HRV, HUN, IMN, IRL, ITA, JEY, LTU, LUX, LVA, MLT, NLD, POL,
+        PRT, ROU, SVK, SVN, SWE
+  - REMIND 2.1|Non-EU28 Europe:
+      countries: ALB, AND, BIH, CHE, GRL, ISL, LIE, MCO, MKD, MNE, NOR, SJM, SMR,
+        SRB, TUR, VAT
 # 21-region version of REMIND
-  - REMIND 2.1|Germany
-  - REMIND 2.1|France
-  - REMIND 2.1|United Kingdom and Ireland
-  - REMIND 2.1|EU Center-East Europe
-  - REMIND 2.1|EU Center-South Europe
-  - REMIND 2.1|EU North-Center Europe
-  - REMIND 2.1|EU South-Center Europe
-  - REMIND 2.1|EU South-West Europe
-  - REMIND 2.1|EU North-West Europe
-  - REMIND 2.1|Non-EU Northern Europe
-  - REMIND 2.1|Non-EU Southern Europe
+  - REMIND 2.1|Germany:
+      countries: DEU
+  - REMIND 2.1|France:
+      countries: FRA
+  - REMIND 2.1|United Kingdom and Ireland:
+      countries: GBR
+  - REMIND 2.1|EU Center-East Europe:
+      countries: ''
+  - REMIND 2.1|EU Center-South Europe:
+      countries: ''
+  - REMIND 2.1|EU North-Center Europe:
+      countries: ''
+  - REMIND 2.1|EU South-Center Europe:
+      countries: ''
+  - REMIND 2.1|EU South-West Europe:
+      countries: ''
+  - REMIND 2.1|EU North-West Europe:
+      countries: ''
+  - REMIND 2.1|Non-EU Northern Europe:
+      countries: ''
+  - REMIND 2.1|Non-EU Southern Europe:
+      countries: ''
 # exogenously aggregated regions
-  - REMIND 2.1|EU 27
+  - REMIND 2.1|EU 27:
+      countries: ''

--- a/definitions/region/model_native_regions/REMIND_3.0.yml
+++ b/definitions/region/model_native_regions/REMIND_3.0.yml
@@ -1,28 +1,65 @@
 - REMIND 3.0:
-  - REMIND 3.0|Canada, Australia, New Zealand
-  - REMIND 3.0|China and Taiwan
-  - REMIND 3.0|India
-  - REMIND 3.0|Japan
-  - REMIND 3.0|Other Asia
-  - REMIND 3.0|Latin America and the Caribbean
-  - REMIND 3.0|Middle East and North Africa
-  - REMIND 3.0|Russia and Reforming Economies
-  - REMIND 3.0|Sub-Saharan Africa
-  - REMIND 3.0|United States of America
+  - REMIND 3.0|Canada, Australia, New Zealand:
+      countries: AUS, CAN, HMD, NZL, SPM
+  - REMIND 3.0|China and Taiwan:
+      countries: CHN, HKG, MAC, TWN
+  - REMIND 3.0|India:
+      countries: IND
+  - REMIND 3.0|Japan:
+      countries: JPN
+  - REMIND 3.0|Other Asia:
+      countries: AFG, ASM, ATF, BGD, BRN, BTN, CCK, COK, CXR, FJI, FSM, GUM, IDN,
+        IOT, KHM, KIR, KOR, LAO, LKA, MDV, MHL, MMR, MNG, MNP, MYS, NCL, NFK, NIU,
+        NPL, NRU, PAK, PCN, PHL, PLW, PNG, PRK, PYF, SGP, SLB, TJK, TKL, TLS, TON,
+        TUV, UMI, VNM, VUT, WLF, WSM
+  - REMIND 3.0|Latin America and the Caribbean:
+      countries: ABW, AIA, ANT, ARG, ATA, ATG, BHS, BLM, BLZ, BMU, BOL, BRA, BRB,
+        BVT, CHL, COL, CRI, CUB, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GTM, GUF, GUY,
+        HND, HTI, JAM, KNA, LCA, MAF, MEX, MSR, MTQ, NIC, PAN, PER, PRI, PRY, SGS,
+        SLV, SUR, TCD, TTO, URY, VCT, VEN, VGB, VIR
+  - REMIND 3.0|Middle East and North Africa:
+      countries: ARE, BHR, DZA, EGY, ESH, IRN, IRQ, ISR, JOR, KWT, LBN, LBY, MAR,
+        OMN, PSE, QAT, SAU, SDN, TCA, TUN, YEM
+  - REMIND 3.0|Russia and Reforming Economies:
+      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TKM, UKR, UZB
+  - REMIND 3.0|Sub-Saharan Africa:
+      countries: AGO, BDI, BEN, BFA, BWA, CAF, CIV, CMR, COD, COG, COM, CPV, DJI,
+        ERI, ETH, GAB, GHA, GIN, GMB, GNB, GNQ, KEN, LBR, LSO, MDG, MLI, MOZ, MRT,
+        MUS, MWI, MYT, NAM, NER, NGA, REU, RWA, SEN, SHN, SLE, SOM, SSD, STP, SWZ,
+        SYC, SYR, TGO, THA, TZA, UGA, ZAF, ZMB, ZWE
+  - REMIND 3.0|United States of America:
+      countries: USA
 # 12-region version of REMIND
-  - REMIND 3.0|EU 28
-  - REMIND 3.0|Non-EU28 Europe
+  - REMIND 3.0|EU 28:
+      countries: ALA, AUT, BEL, BGR, CYP, CZE, DEU, DNK, ESP, EST, FIN, FRA, FRO,
+        GGY, GIB, GRC, HRV, HUN, IMN, IRL, ITA, JEY, LTU, LUX, LVA, MLT, NLD, POL,
+        PRT, ROU, SVK, SVN, SWE
+  - REMIND 3.0|Non-EU28 Europe:
+      countries: ALB, AND, BIH, CHE, GRL, ISL, LIE, MCO, MKD, MNE, NOR, SJM, SMR,
+        SRB, TUR, VAT
 # 21-region version of REMIND
-  - REMIND 3.0|Germany
-  - REMIND 3.0|France
-  - REMIND 3.0|United Kingdom and Ireland
-  - REMIND 3.0|EU Center-East Europe
-  - REMIND 3.0|EU Center-South Europe
-  - REMIND 3.0|EU North-Center Europe
-  - REMIND 3.0|EU South-Center Europe
-  - REMIND 3.0|EU South-West Europe
-  - REMIND 3.0|EU North-West Europe
-  - REMIND 3.0|Non-EU Northern Europe
-  - REMIND 3.0|Non-EU Southern Europe
+  - REMIND 3.0|Germany:
+      countries: DEU
+  - REMIND 3.0|France:
+      countries: FRA
+  - REMIND 3.0|United Kingdom and Ireland:
+      countries: GBR
+  - REMIND 3.0|EU Center-East Europe:
+      countries: ''
+  - REMIND 3.0|EU Center-South Europe:
+      countries: ''
+  - REMIND 3.0|EU North-Center Europe:
+      countries: ''
+  - REMIND 3.0|EU South-Center Europe:
+      countries: ''
+  - REMIND 3.0|EU South-West Europe:
+      countries: ''
+  - REMIND 3.0|EU North-West Europe:
+      countries: ''
+  - REMIND 3.0|Non-EU Northern Europe:
+      countries: ''
+  - REMIND 3.0|Non-EU Southern Europe:
+      countries: ''
 # exogenously aggregated regions
-  - REMIND 3.0|EU 27
+  - REMIND 3.0|EU 27:
+      countries: ''

--- a/definitions/region/model_native_regions/REMIND_3.0.yml
+++ b/definitions/region/model_native_regions/REMIND_3.0.yml
@@ -10,30 +10,30 @@
   - REMIND 3.0|Other Asia:
       countries: AFG, ASM, ATF, BGD, BRN, BTN, CCK, COK, CXR, FJI, FSM, GUM, IDN,
         IOT, KHM, KIR, KOR, LAO, LKA, MDV, MHL, MMR, MNG, MNP, MYS, NCL, NFK, NIU,
-        NPL, NRU, PAK, PCN, PHL, PLW, PNG, PRK, PYF, SGP, SLB, TJK, TKL, TLS, TON,
+        NPL, NRU, PAK, PCN, PHL, PLW, PNG, PRK, PYF, SGP, SLB, TKL, TLS, TON, THA
         TUV, UMI, VNM, VUT, WLF, WSM
   - REMIND 3.0|Latin America and the Caribbean:
       countries: ABW, AIA, ANT, ARG, ATA, ATG, BHS, BLM, BLZ, BMU, BOL, BRA, BRB,
         BVT, CHL, COL, CRI, CUB, CYM, DMA, DOM, ECU, FLK, GLP, GRD, GTM, GUF, GUY,
         HND, HTI, JAM, KNA, LCA, MAF, MEX, MSR, MTQ, NIC, PAN, PER, PRI, PRY, SGS,
-        SLV, SUR, TCD, TTO, URY, VCT, VEN, VGB, VIR
+        SLV, SUR, TTO, URY, VCT, VEN, VGB, VIR, BES, CUW, SXM, TCA
   - REMIND 3.0|Middle East and North Africa:
       countries: ARE, BHR, DZA, EGY, ESH, IRN, IRQ, ISR, JOR, KWT, LBN, LBY, MAR,
-        OMN, PSE, QAT, SAU, SDN, TCA, TUN, YEM
+        OMN, PSE, QAT, SAU, SDN, TUN, YEM, SYR
   - REMIND 3.0|Russia and Reforming Economies:
-      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TKM, UKR, UZB
+      countries: ARM, AZE, BLR, GEO, KAZ, KGZ, MDA, RUS, TKM, UKR, UZB, TJK
   - REMIND 3.0|Sub-Saharan Africa:
       countries: AGO, BDI, BEN, BFA, BWA, CAF, CIV, CMR, COD, COG, COM, CPV, DJI,
         ERI, ETH, GAB, GHA, GIN, GMB, GNB, GNQ, KEN, LBR, LSO, MDG, MLI, MOZ, MRT,
         MUS, MWI, MYT, NAM, NER, NGA, REU, RWA, SEN, SHN, SLE, SOM, SSD, STP, SWZ,
-        SYC, SYR, TGO, THA, TZA, UGA, ZAF, ZMB, ZWE
+        SYC, TGO, TZA, UGA, ZAF, ZMB, ZWE, TCD
   - REMIND 3.0|United States of America:
       countries: USA
 # 12-region version of REMIND
   - REMIND 3.0|EU 28:
-      countries: ALA, AUT, BEL, BGR, CYP, CZE, DEU, DNK, ESP, EST, FIN, FRA, FRO,
-        GGY, GIB, GRC, HRV, HUN, IMN, IRL, ITA, JEY, LTU, LUX, LVA, MLT, NLD, POL,
-        PRT, ROU, SVK, SVN, SWE
+      countries: ALA, AUT, BEL, BGR, CYP, CZE, DNK, ESP, EST, FIN, FRO, GGY, GIB,
+        GRC, HRV, HUN, IMN, IRL, ITA, JEY, LTU, LUX, LVA, MLT, NLD, POL, PRT, ROU,
+        SVK, SVN, SWE, FRA, DEU, ITA, GIB, GGY, GBR
   - REMIND 3.0|Non-EU28 Europe:
       countries: ALB, AND, BIH, CHE, GRL, ISL, LIE, MCO, MKD, MNE, NOR, SJM, SMR,
         SRB, TUR, VAT
@@ -43,23 +43,24 @@
   - REMIND 3.0|France:
       countries: FRA
   - REMIND 3.0|United Kingdom and Ireland:
-      countries: GBR
+      countries: GIB, GGY, IRL, IMN, JEY, GBR
   - REMIND 3.0|EU Center-East Europe:
-      countries: ''
+      countries: CZE, EST, LVA, LTU, POL, SVK
   - REMIND 3.0|EU Center-South Europe:
-      countries: ''
+      countries: BGR, HRV, HUN, ROU, SVN
   - REMIND 3.0|EU North-Center Europe:
-      countries: ''
+      countries: ALA, DNK, FRO, FIN, SWE
   - REMIND 3.0|EU South-Center Europe:
-      countries: ''
+      countries: CYP, GRC, ITA, MLT
   - REMIND 3.0|EU South-West Europe:
-      countries: ''
+      countries: PRT, ESP
   - REMIND 3.0|EU North-West Europe:
-      countries: ''
+      countries: AUT, BEL, LUX, NLD
   - REMIND 3.0|Non-EU Northern Europe:
-      countries: ''
+      countries: ISL, LIE, NOR, SJM, CHE, GRL
   - REMIND 3.0|Non-EU Southern Europe:
-      countries: ''
+      countries: ALB, AND, BIH, VAT, MKD, MCO, MNE, SMR, SRB, TUR
 # exogenously aggregated regions
   - REMIND 3.0|EU 27:
-      countries: ''
+      countries: ALA, AUT, BEL, BGR, HRV, CYP, CZE, DNK, EST, FRO, FIN, FRA, DEU, GRC,
+        HUN, ITA, LVA, LTU, LUX, MLT, NLD, POL, PRT, ROU, SVK, SVN, ESP, SWE


### PR DESCRIPTION
For use in automated processing and validation, this PR adds the ISO3-codes to the native regions of the REMIND model - could you please double-check and add the right ISO3-codes for the European regions?